### PR TITLE
Fix sample config port

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
-	"code.google.com/p/gcfg"
+	"github.com/kardianos/osext"
+	"gopkg.in/gcfg.v1"
 	"github.com/influxdb/influxdb/client"
 	"github.com/soniah/gosnmp"
 )

--- a/sample_config.gcfg
+++ b/sample_config.gcfg
@@ -54,13 +54,15 @@ column = ifHCInOctets
 column = ifHCOutOctets
 
 [influx "*"]
-host = localhost:8086
+host = localhost
+port = 8086
 db   = dbname
 user = username
 password = password
 
 [influx "switch"]
-host = 192.168.1.254:8086
+host = 192.168.1.254
+port = 8086
 db   = otherdb
 user = othername
 password = otherpass 


### PR DESCRIPTION
Fixed sample_config.gcfg, otherwise users get this message:
2015/10/20 21:51:00 failed connecting to: localhost:8086
2015/10/20 21:51:00 error: Get http://localhost:8086:0/ping: dial tcp: too many colons in address localhost:8086:0
2015/10/20 21:51:00 Get http://localhost:8086:0/ping: dial tcp: too many colons in address localhost:8086:0
